### PR TITLE
fastAPI에 쓰이는 리스트콜 5년내 보고서 전부 응답으로 전환

### DIFF
--- a/src/main/java/com/example/finalproject/dart/controller/DartController.java
+++ b/src/main/java/com/example/finalproject/dart/controller/DartController.java
@@ -42,9 +42,15 @@ public class DartController {
     }
 
     // 기업코드로 최근 1년간의 사업/1분기/3분기/반기/감사 보고서의 리스트 반환
+//    @GetMapping("/reports/core")
+//    public DartReportListResponseDto test(@RequestParam("corp_code") String corpCode){
+//        return dartApiService.getRceptNosByCorpCode(corpCode); // "01571107"
+//    }
+
+    // 기업코드로 최근 5년간의 모든 보고서의 리스트 반환
     @GetMapping("/reports/core")
-    public DartReportListResponseDto test(@RequestParam("corp_code") String corpCode){
-        return dartApiService.getRceptNosByCorpCode(corpCode); // "01571107"
+    public DartReportListResponseDto fiveYearRceptCall(@RequestParam("corp_code") String corpCode){
+        return dartApiService.getFiveYearRceptNosByCorpCode(corpCode); // "01571107"
     }
 
 

--- a/src/main/java/com/example/finalproject/dart/service/DartApiService.java
+++ b/src/main/java/com/example/finalproject/dart/service/DartApiService.java
@@ -39,6 +39,8 @@ public interface DartApiService {
     // 기업코드로 최근 1년간의 사업/1분기/3분기/반기/감사 보고서의 리스트 반환
     DartReportListResponseDto getRceptNosByCorpCode(String corpCode);
 
+    // 기업코드로 최근 5년간의 모든 보고서 리스트 반환
+    DartReportListResponseDto getFiveYearRceptNosByCorpCode(String corpCode);
 
 }
 /*

--- a/src/main/java/com/example/finalproject/dart/service/impl/DartApiServiceImpl.java
+++ b/src/main/java/com/example/finalproject/dart/service/impl/DartApiServiceImpl.java
@@ -512,6 +512,19 @@ public class DartApiServiceImpl implements DartApiService {
         return rpt_all;
     }
 
+    // 기업코드로 최근 5년간의 보고서의 리스트 반환
+    @Override
+    public DartReportListResponseDto getFiveYearRceptNosByCorpCode(String corpCode){
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+        LocalDate today = LocalDate.now();
+        String todayString = today.format(formatter);
+
+        LocalDate fiveYearAgo = today.minusYears(5);
+        String fiveYearAgoString = fiveYearAgo.format(formatter);
+
+        // 회사코드(corpCode)를 통해서 api로 (회사정보,(보고서리스트))를 가져옴(최대 100개)
+        return getCompanyInfoByCorpCode(corpCode, new DownloadAllRequestDto("보고서",fiveYearAgoString,todayString));
+    }
 /*
     1. xml 1개 다운하던걸 폴더 만들어서 내부 파일 전부 바꾸는걸로 전환
     2.


### PR DESCRIPTION
### ✨ 개선 사항
> fastAPI의 보고서 파싱에 쓰이는 보고서 리스트응답을 5년내 보고서 전부 응답으로 전환

<br>

### ✅ PR 체크리스트
- [x] 커밋 컨벤션을 지켰나요?
- [x] 관련 이슈를 연결했나요?

<br>

### 🔗 참고 사항
> 리뷰어가 참고할 만한 내용을 공유해주세요.

---
Resolved #이슈번호
